### PR TITLE
Remove project name from s3 bucket because it exists in the account alias

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -2,7 +2,7 @@ module "athena_results" {
   source  = "trussworks/s3-private-bucket/aws"
   version = "~> 3.2.1"
 
-  bucket = format("%s-%s-%s-athena-results", data.aws_region.current.name, var.project, var.environment)
+  bucket = format("%s-%s-athena-results", data.aws_region.current.name, var.environment)
   tags   = local.project_tags
 
   logging_bucket = module.aws_logs.aws_logs_bucket
@@ -12,7 +12,7 @@ module "glue_tmp_bucket" {
   source  = "trussworks/s3-private-bucket/aws"
   version = "~> 3.2.1"
 
-  bucket = format("%s-%s-%s-glue-tmp", data.aws_region.current.name, var.project, var.environment)
+  bucket = format("%s-%s-glue-tmp", data.aws_region.current.name, var.environment)
   tags   = local.project_tags
 
   logging_bucket = module.aws_logs.aws_logs_bucket
@@ -22,6 +22,6 @@ module "aws_logs" {
   source  = "trussworks/logs/aws"
   version = "~> 10.0.0"
 
-  s3_bucket_name = format("%s-%s-%s-aws-logs", data.aws_region.current.name, var.project, var.environment)
+  s3_bucket_name = format("%s-%s-aws-logs", data.aws_region.current.name, var.environment)
   tags           = local.project_tags
 }


### PR DESCRIPTION
Ran into this problem due to longer account alias names.