### PR TITLE
display frequencies of policy after partitions

### DIFF
--- a/athena.tf
+++ b/athena.tf
@@ -122,3 +122,29 @@ resource "aws_athena_named_query" "num_records" {
   database  = split(":", aws_glue_catalog_database.shepherd[count.index].id)[1]
   query     = format("select count(*) from \"%s\".\"%s\"", split(":", aws_glue_catalog_database.shepherd[count.index].id)[1], local.table_name)
 }
+  
+
+resource "aws_athena_named_query" "policy-freq" {
+  count = length(var.subscriber_buckets)
+
+  name      = format("%s-%s-num-records", local.glue_database_name_prefix, var.subscriber_buckets[count.index])
+  workgroup = aws_athena_workgroup.shepherd[count.index].id
+  database  = split(":", aws_glue_catalog_database.shepherd[count.index].id)[1]
+  query     = <<-EOT
+      select policy, count(*) as freq from
+
+      (SELECT array_join(policies, ' ') AS policy
+      from shepherd_global_database_sub_hhs_secops_f23sihm4.dns_data 
+      where rec_type='base'
+       and subscriber='sub.hhs.secops'
+        and dns_question_rdtype='A'
+        and hour >= (cast(to_unixtime(now()) as integer) -  (60 * 60 * 24 * 3)) 
+       and policies is not null
+      order by policy)
+      as SUBQUERY
+
+      where policy not like '%safe%'
+      and policy not like '%schedule%'
+      and policy not like '%custom%'
+      group by policy
+      order by freq desc;


### PR DESCRIPTION
My commentary and results of this query are here: https://dds.atlassian.net/wiki/spaces/SEN/pages/859045889/Visualizations+with+Quicksight

I have attempted to follow the example you provided for other named queries in this same script.