### PR TITLE
added query for policy freqs

### DIFF
--- a/athena.tf
+++ b/athena.tf
@@ -123,19 +123,20 @@ resource "aws_athena_named_query" "num_records" {
   query     = format("select count(*) from \"%s\".\"%s\"", split(":", aws_glue_catalog_database.shepherd[count.index].id)[1], local.table_name)
 }
 
+# Example Athena query using partition filter provided by Kelli
 resource "aws_athena_named_query" "policy-freq" {
-  count = length(var.subscriber_buckets)
+  count     = length(var.subscriber_buckets)
   name      = format("%s-%s-policy-freq", local.glue_database_name_prefix, var.subscriber_buckets[count.index])
   workgroup = aws_athena_workgroup.shepherd[count.index].id
   database  = split(":", aws_glue_catalog_database.shepherd[count.index].id)[1]
   query     = <<-EOT
       select policy, count(*) as freq from
       (SELECT array_join(policies, ' ') AS policy
-      from shepherd_global_database_sub_hhs_secops_f23sihm4.dns_data 
+      from shepherd_global_database_sub_hhs_secops_f23sihm4.dns_data
       where rec_type='base'
        and subscriber='sub.hhs.secops'
         and dns_question_rdtype='A'
-        and hour >= (cast(to_unixtime(now()) as integer) -  (60 * 60 * 24 * 3)) 
+        and hour >= (cast(to_unixtime(now()) as integer) -  (60 * 60 * 24 * 3))
        and policies is not null
       order by policy)
       as SUBQUERY
@@ -145,4 +146,4 @@ resource "aws_athena_named_query" "policy-freq" {
       group by policy
       order by freq desc;
     EOT
-    }
+}

--- a/athena.tf
+++ b/athena.tf
@@ -140,9 +140,9 @@ resource "aws_athena_named_query" "policy-freq" {
        and policies is not null
       order by policy)
       as SUBQUERY
-      where policy not like '%%safe%%'
-      and policy not like '%%schedule%%'
-      and policy not like '%%custom%%'
+      where policy not like '%safe%'
+      and policy not like '%schedule%'
+      and policy not like '%custom%'
       group by policy
       order by freq desc;
     EOT

--- a/athena.tf
+++ b/athena.tf
@@ -122,3 +122,27 @@ resource "aws_athena_named_query" "num_records" {
   database  = split(":", aws_glue_catalog_database.shepherd[count.index].id)[1]
   query     = format("select count(*) from \"%s\".\"%s\"", split(":", aws_glue_catalog_database.shepherd[count.index].id)[1], local.table_name)
 }
+
+resource "aws_athena_named_query" "policy-freq" {
+  count = length(var.subscriber_buckets)
+  name      = format("%s-%s-policy-freq", local.glue_database_name_prefix, var.subscriber_buckets[count.index])
+  workgroup = aws_athena_workgroup.shepherd[count.index].id
+  database  = split(":", aws_glue_catalog_database.shepherd[count.index].id)[1]
+  query     = <<-EOT
+      select policy, count(*) as freq from
+      (SELECT array_join(policies, ' ') AS policy
+      from shepherd_global_database_sub_hhs_secops_f23sihm4.dns_data 
+      where rec_type='base'
+       and subscriber='sub.hhs.secops'
+        and dns_question_rdtype='A'
+        and hour >= (cast(to_unixtime(now()) as integer) -  (60 * 60 * 24 * 3)) 
+       and policies is not null
+      order by policy)
+      as SUBQUERY
+      where policy not like '%%safe%%'
+      and policy not like '%%schedule%%'
+      and policy not like '%%custom%%'
+      group by policy
+      order by freq desc;
+    EOT
+    }


### PR DESCRIPTION
@chrisgilmerproj 
I have incorporated your suggestions from our phone call
Adding a named query that extracts frequencies by policy, after applying appropriate `where` statements for partitioning.
Results of this query are here: https://dds.atlassian.net/wiki/spaces/SEN/pages/859045889/Visualizations+with+Quicksight